### PR TITLE
feat(Button): add href prop for linkable buttons and implement disabled tab state

### DIFF
--- a/src/components/Button/Button.stories.jsx
+++ b/src/components/Button/Button.stories.jsx
@@ -22,6 +22,10 @@ export default {
 			control: 'text',
 			description: 'Emoji or icon text (e.g. 🔍)',
 		},
+		href: {
+			control: 'text',
+			description: 'URL for linkable button',
+		},
 		onClick: { action: 'clicked' },
 	},
 };
@@ -92,5 +96,22 @@ export const WithIcon = {
 		label: 'Search',
 		icon: '🔍',
 		variant: 'secondary',
+	},
+};
+
+// ✅ Linkable Buttons
+export const LinkButton = {
+	args: {
+		label: 'Go to Dashboard',
+		variant: 'primary',
+		href: '/dashboard',
+	},
+};
+
+export const ExternalLinkButton = {
+	args: {
+		label: 'Visit Website',
+		variant: 'secondary',
+		href: 'https://example.com',
 	},
 };

--- a/src/components/Tabs/Tabs.jsx
+++ b/src/components/Tabs/Tabs.jsx
@@ -3,23 +3,23 @@ import { clsx } from 'clsx';
 
 export const Tabs = ({ tabs, defaultActive = 0, onTabChange, variant = 'underline' }) => {
 	const [activeIndex, setActiveIndex] = useState(defaultActive);
+	const isPill = variant === 'pill';
 
 	const handleTabClick = index => {
+		if (tabs[index].disabled) return;
 		setActiveIndex(index);
 		onTabChange?.(tabs[index]);
 	};
 
-	const isPill = variant === 'pill';
-
 	return (
 		<div className='w-full'>
-			{/* Tab list */}
 			<div
 				role='tablist'
 				className={clsx('flex space-x-2', !isPill && 'border-b border-gray-200')}
 			>
 				{tabs.map((tab, index) => {
 					const isActive = index === activeIndex;
+
 					return (
 						<button
 							type='button'
@@ -27,9 +27,11 @@ export const Tabs = ({ tabs, defaultActive = 0, onTabChange, variant = 'underlin
 							role='tab'
 							aria-selected={isActive}
 							aria-controls={`tab-panel-${index}`}
+							disabled={tab.disabled}
 							onClick={() => handleTabClick(index)}
 							className={clsx(
 								'px-4 py-2 text-sm transition-all duration-200',
+								tab.disabled && 'opacity-50 cursor-not-allowed',
 								isPill
 									? isActive
 										? 'bg-indigo-100 text-indigo-700 rounded-full border-2 border-indigo-600'
@@ -46,7 +48,6 @@ export const Tabs = ({ tabs, defaultActive = 0, onTabChange, variant = 'underlin
 				})}
 			</div>
 
-			{/* Tab content */}
 			<div id={`tab-panel-${activeIndex}`} role='tabpanel' className='pt-4'>
 				{tabs[activeIndex]?.content}
 			</div>

--- a/src/components/Tabs/Tabs.stories.jsx
+++ b/src/components/Tabs/Tabs.stories.jsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Tabs } from './Tabs';
 
 export default {
@@ -88,6 +89,39 @@ export const RoundedTabs = {
 		docs: {
 			description: {
 				story: 'Tabs with a rounded background pill style when active.',
+			},
+		},
+	},
+};
+
+export const WithDisabledTab = {
+	name: 'With a Disabled Tab',
+	args: {
+		tabs: [
+			{
+				label: 'Active Tab',
+				icon: '✅',
+				content: <p>This tab is active and clickable.</p>,
+			},
+			{
+				label: 'Disabled Tab',
+				icon: '⛔',
+				content: <p>You should not be able to activate this tab.</p>,
+				disabled: true,
+			},
+			{
+				label: 'Another Tab',
+				icon: '📦',
+				content: <p>This one works like normal.</p>,
+			},
+		],
+		defaultActive: 0,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Demonstrates a disabled tab that is visually distinct and cannot be clicked.',
 			},
 		},
 	},


### PR DESCRIPTION
Add support for linkable buttons by introducing href prop. Also includes new storybook examples for internal and external links.

Add disabled state support for tabs with visual indicators and prevent click events on disabled tabs. Includes new storybook example demonstrating the feature.